### PR TITLE
Allow setting lb DNS records for seperate GCP project

### DIFF
--- a/production/terraform/gcp/modules/kv_server/main.tf
+++ b/production/terraform/gcp/modules/kv_server/main.tf
@@ -118,6 +118,7 @@ module "external_load_balancing" {
   internal_load_balancer           = module.service_mesh.internal_load_balancer
   grpc_route                       = module.service_mesh.grpc_route
   server_ip_address                = module.networking.server_ip_address
+  lb_dns_zones_project_id          = var.lb_dns_zones_project_id
 }
 
 module "parameter" {

--- a/production/terraform/gcp/modules/kv_server/variables.tf
+++ b/production/terraform/gcp/modules/kv_server/variables.tf
@@ -202,3 +202,9 @@ variable "enable_external_traffic" {
   default     = true
   type        = bool
 }
+
+variable "lb_dns_zones_project_id" {
+  description = "The name of the Google Cloud project where DNS zones are managed."
+  type        = string
+  default     = null
+}

--- a/production/terraform/gcp/services/external_load_balancing/main.tf
+++ b/production/terraform/gcp/services/external_load_balancing/main.tf
@@ -72,6 +72,7 @@ resource "google_compute_global_forwarding_rule" "xlb_https" {
 resource "google_dns_record_set" "default" {
   name         = "${var.server_url}."
   managed_zone = var.server_dns_zone
+  project      = var.lb_dns_zones_project_id
   type         = "A"
   ttl          = 10
   rrdatas = [

--- a/production/terraform/gcp/services/external_load_balancing/variables.tf
+++ b/production/terraform/gcp/services/external_load_balancing/variables.tf
@@ -63,3 +63,9 @@ variable "grpc_route" {
   description = "Google network services grpc route for kv_server"
   type        = string
 }
+
+variable "lb_dns_zones_project_id" {
+  description = "The name of the Google Cloud project where DNS zones are managed."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
Add `lb_dns_zones_project_id` to service level to configure the resource "google_dns_record_set" "collector" The existing setup assumes that the GCP project used for kv is also responsible managing DNS and domains, which isn't always the case.