### PR TITLE
Add terraform variable to force AWS availability zones

### DIFF
--- a/production/terraform/aws/environments/demo/us-east-1.tfvars.json
+++ b/production/terraform/aws/environments/demo/us-east-1.tfvars.json
@@ -18,6 +18,7 @@
   "environment": "demo",
   "existing_vpc_environment": "",
   "existing_vpc_operator": "",
+  "forced_availability_zones": [],
   "healthcheck_grace_period_sec": 60,
   "healthcheck_healthy_threshold": 3,
   "healthcheck_interval_sec": 30,

--- a/production/terraform/aws/environments/demo/us-west-1.tfvars.json
+++ b/production/terraform/aws/environments/demo/us-west-1.tfvars.json
@@ -12,6 +12,7 @@
   "enclave_enable_debug_mode": true,
   "enclave_memory_mib": 3072,
   "environment": "demo",
+  "forced_availability_zones": [],
   "healthcheck_healthy_threshold": 3,
   "healthcheck_interval_sec": 30,
   "healthcheck_unhealthy_threshold": 3,

--- a/production/terraform/aws/environments/kv_server.tf
+++ b/production/terraform/aws/environments/kv_server.tf
@@ -22,15 +22,16 @@ module "kv_server" {
   region      = var.region
 
   # Variables related to network, dns and certs configuration.
-  vpc_cidr_block           = var.vpc_cidr_block
-  root_domain              = var.root_domain
-  root_domain_zone_id      = var.root_domain_zone_id
-  certificate_arn          = var.certificate_arn
-  use_existing_vpc         = var.use_existing_vpc
-  existing_vpc_operator    = var.existing_vpc_operator
-  existing_vpc_environment = var.existing_vpc_environment
-  enable_external_traffic  = var.enable_external_traffic
-  with_existing_kv         = var.with_existing_kv
+  vpc_cidr_block            = var.vpc_cidr_block
+  root_domain               = var.root_domain
+  root_domain_zone_id       = var.root_domain_zone_id
+  certificate_arn           = var.certificate_arn
+  use_existing_vpc          = var.use_existing_vpc
+  existing_vpc_operator     = var.existing_vpc_operator
+  existing_vpc_environment  = var.existing_vpc_environment
+  enable_external_traffic   = var.enable_external_traffic
+  with_existing_kv          = var.with_existing_kv
+  forced_availability_zones = var.forced_availability_zones
 
   # Variables related to EC2 instances.
   instance_type   = var.instance_type

--- a/production/terraform/aws/environments/kv_server_variables.tf
+++ b/production/terraform/aws/environments/kv_server_variables.tf
@@ -380,3 +380,9 @@ variable "with_existing_kv" {
   default     = false
   type        = bool
 }
+
+variable "forced_availability_zones" {
+  description = "Only use those forced availability zones. Not all instances types are available in all zones"
+  type        = set(string)
+  default     = []
+}

--- a/production/terraform/aws/modules/kv_server/main.tf
+++ b/production/terraform/aws/modules/kv_server/main.tf
@@ -36,13 +36,14 @@ module "data_storage" {
 }
 
 module "networking" {
-  source                   = "../../services/networking"
-  service                  = local.service
-  environment              = var.environment
-  vpc_cidr_block           = var.vpc_cidr_block
-  use_existing_vpc         = var.use_existing_vpc
-  existing_vpc_operator    = var.existing_vpc_operator
-  existing_vpc_environment = var.existing_vpc_environment
+  source                    = "../../services/networking"
+  service                   = local.service
+  environment               = var.environment
+  vpc_cidr_block            = var.vpc_cidr_block
+  use_existing_vpc          = var.use_existing_vpc
+  existing_vpc_operator     = var.existing_vpc_operator
+  existing_vpc_environment  = var.existing_vpc_environment
+  forced_availability_zones = var.forced_availability_zones
 }
 
 module "security_groups" {

--- a/production/terraform/aws/modules/kv_server/variables.tf
+++ b/production/terraform/aws/modules/kv_server/variables.tf
@@ -376,3 +376,9 @@ variable "coordinator_role_arns" {
   description = "ARNs for coordinator roles."
   type        = list(string)
 }
+
+variable "forced_availability_zones" {
+  description = "Only use those forced availability zones. Not all instances types are available in all zones"
+  type        = set(string)
+  default     = []
+}

--- a/production/terraform/aws/services/networking/main.tf
+++ b/production/terraform/aws/services/networking/main.tf
@@ -97,6 +97,14 @@ resource "aws_vpc" "vpc" {
 # Get information about available AZs.
 data "aws_availability_zones" "azs" {
   state = "available"
+  dynamic "filter" {
+  for_each = length(var.forced_availability_zones) > 0 ? [1] : []
+
+    content {
+      name   = "zone-name"
+      values = var.forced_availability_zones
+    }
+  }
 }
 
 # Create public subnets used to connect to instances in private subnets.

--- a/production/terraform/aws/services/networking/variables.tf
+++ b/production/terraform/aws/services/networking/variables.tf
@@ -42,3 +42,10 @@ variable "existing_vpc_environment" {
   description = "Environment of the existing VPC. Ingored if use_existing_vpc is false."
   type        = string
 }
+
+
+variable "forced_availability_zones" {
+  description = "Only use those forced availability zones."
+  type = set(string)
+  default     = []
+}


### PR DESCRIPTION
This adds forced_availability_zones. By default all zones are selected, not all instances types are available on all zones which may produce errors, setting allows to select a subset of zones.

This was already introduced for B&A in [https://github.com/privacysandbox/bidding-auction-servers/pull/44](https://github.com/privacysandbox/bidding-auction-servers/pull/44)